### PR TITLE
packer 1.7 requires a sha256 checksum

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Binary Release
 
-on: 
+on:
   release:
     types: [created]
 
@@ -20,3 +20,4 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
+        sha256sum: true


### PR DESCRIPTION
```
could not get sha256 checksum file for github.com/caulagi/goss version 3.0.3. Is the file present on the release and correctly named ? GET https://github.com/caulagi/packer-plugin-goss/releases/download/v3.0.3/packer-plugin-goss_v3.0.3_SHA256SUMS: 404  []
```

Signed-off-by: Pradip Caulagi <caulagi@gmail.com>